### PR TITLE
urlparse was renamed in python 3

### DIFF
--- a/netort/resource.py
+++ b/netort/resource.py
@@ -7,7 +7,7 @@ import hashlib
 import serial
 import yaml
 import socket
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 from contextlib import closing
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
'from six.moves.urllib.parse import urlparse' should work in python 2 and 3